### PR TITLE
Fix snow agg

### DIFF
--- a/era5_variables.py
+++ b/era5_variables.py
@@ -325,8 +325,8 @@ era5_datavar_lut: Dict[str, Dict[str, Any]] = {
         "short_name": "swe",
         "standard_name": "surface_snow_amount",
         "units": "kg m-2",
-        "agg_func": lambda x: x.sum(dim="Time"),
-        "description": "Daily accumulated snow water equivalent",
+        "agg_func": lambda x: x.mean(dim="Time"),
+        "description": "Daily mean snow water equivalent",
     },
     "snowh_mean": {
         "var_id": "SNOWH",

--- a/era5_variables.py
+++ b/era5_variables.py
@@ -320,7 +320,7 @@ era5_datavar_lut: Dict[str, Dict[str, Any]] = {
         "agg_func": lambda x: x.max(dim="Time"),
         "description": "Daily maximum vertical wind component",
     },
-    "snow_sum": {
+    "snow_mean": {
         "var_id": "SNOW",
         "short_name": "swe",
         "standard_name": "surface_snow_amount",


### PR DESCRIPTION
Closes #20 

This PR changes the snow (SWE) aggregation method from sum to mean, and renames the resulting variable for clarity. To test, run the pipeline for 4km and/or 12km data to ensure the processing completes. Review the attached notebook which compares files from the previous aggregation method with files produced from the new aggregation method. 
[era5_snow_sum_vs_mean.ipynb](https://github.com/user-attachments/files/28518268/era5_snow_sum_vs_mean.ipynb)
